### PR TITLE
cdc: 解决跨文件调用报错。

### DIFF
--- a/UI/UI_test.py
+++ b/UI/UI_test.py
@@ -4,7 +4,7 @@ from Button_class import Button
 from Label_Class import Label
 import sys
 import os
-from Web.identify_client import IdentifyClient as ic
+from Web import identify_client as ic
 pygame.init()
 screen = pygame.display.set_mode((1200, 800))
 """页面状态"""
@@ -96,7 +96,7 @@ r_check_button = Button('check', SENDCHECK, check_rect, "Img/light_butbg.png", 0
 # confirm_button = Button('confirm', CONFIRM, confirm_rect, "Img/light_butbg.png", 0, '确认', register_font)
 """注册测试"""
 check_code = ''
-identify_client = ic("47.100.69.244", 25555, "124.223.215.89", 25555)
+identify_client = ic.createIdentifyClient()
 running = True
 while running:
     if page_status == 0:

--- a/Web/identify_client.py
+++ b/Web/identify_client.py
@@ -1,6 +1,6 @@
 import Web.Modules.safeclient as safeclient
 import json
-
+import os
 
 class IdentifyClient:
     def __init__(self, reg_ip: str, reg_port: int,
@@ -78,7 +78,10 @@ class IdentifyClient:
 
 
 def createIdentifyClient() -> IdentifyClient:
-    with open("Modules/settings.json", "r") as f:
+    current_path = os.getcwd()
+    fag_directory = os.path.dirname(current_path)
+    os.chdir(fag_directory)
+    with open("Web/Modules/settings.json", "r") as f:
         information = json.load(f)
     reg_ip = information["Client"]["Reg_IP"]
     reg_port = information["Client"]["Reg_Port"]


### PR DESCRIPTION
* 修改了identify_client里面创建ic对象的文件操作，使得跨文件调用不会报错